### PR TITLE
[Webapp] User Id Token Cookie Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.1.0",
     "bootstrap": "^5.3.2",
+    "js-cookie": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "path": "^0.12.7",
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.0",
@@ -19,6 +21,7 @@
     "react-router-dom": "^6.16.0"
   },
   "devDependencies": {
+    "@types/js-cookie": "^3.0.6",
     "@types/node": "^20.8.6",
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { Container } from "react-bootstrap";
-import { useSelector } from "react-redux";
 
 import "./App.scss";
-import Account from "./pages/Account/Account";
 import { GlobalProvider } from "./providers/GlobalProvider";
 import Header from "./components/Header/Header";
 import Home from "./pages/Home/Home";
@@ -13,13 +11,8 @@ import Rooms from "./pages/Rooms/Rooms";
 import Tenant from "./pages/Tenant/Tenant";
 import Tenants from "./pages/Tenants/Tenants";
 import Transactions from "./pages/Transactions/Transactions";
-import type { RootState } from "./store";
 
 const App = () => {
-  const user = useSelector((state: RootState) => state.auth.user);
-  const AccountRedirectRoute = user ? <Navigate to="/" /> : <Account />;
-  const CatchAllRoute = user ? <NotFound /> : <Navigate to="/account" />;
-
   return (
     <BrowserRouter>
       <GlobalProvider>
@@ -40,8 +33,7 @@ const App = () => {
                   <Route path="/transactions" element={<Transactions />} />
                 </Route>
               </Route>
-              <Route path="/account" element={AccountRedirectRoute} />
-              <Route path="*" element={CatchAllRoute} />
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </Container>
         </div>

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -3,6 +3,7 @@
 .navbar {
   .navbar-brand,
   .nav-link {
+    cursor: pointer;
     margin: 0 0.5rem;
     padding: 0.5rem 0 !important;
     position: relative;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import Container from "react-bootstrap/Container";
-import { FC } from "react";
+import { FC, MouseEvent } from "react";
 import { Link } from "react-router-dom";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
@@ -14,7 +14,8 @@ const Header: FC = () => {
   );
   const dispatch = useDispatch();
 
-  const handleLogout = () => {
+  const handleLogout = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
     dispatch(logout());
   };
 
@@ -37,11 +38,11 @@ const Header: FC = () => {
     user && (
       <>
         <Navbar.Text>
-          Logged in as <span className="username">{user.name}</span>
+          Logged in as <span className="username">{user.email}</span>
         </Navbar.Text>
-        <Link className="nav-link" to="/account" onClick={handleLogout}>
+        <a className="nav-link" onClick={handleLogout}>
           Sign Out
-        </Link>
+        </a>
       </>
     );
 

--- a/src/components/PrivateRoutes/PrivateRoutes.tsx
+++ b/src/components/PrivateRoutes/PrivateRoutes.tsx
@@ -11,13 +11,10 @@ export interface PrivateRoutesProps {
 
 const PrivateRoute: FC<PrivateRoutesProps> = ({ roles }) => {
   const dispatch = useDispatch();
-  const { logoutUri, user } = useSelector((state: RootState) => state.auth);
+  const { user } = useSelector((state: RootState) => state.auth);
 
   if (!user) {
-    if (logoutUri) {
-      dispatch(logout());
-    }
-    return <Forbidden />;
+    dispatch(logout());
   } else if (roles && !roles.includes(user.role)) {
     return <Forbidden />;
   } else {

--- a/src/components/PrivateRoutes/PrivateRoutes.tsx
+++ b/src/components/PrivateRoutes/PrivateRoutes.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 import Forbidden from "@/pages/ErrorPages/Forbidden";
@@ -13,7 +13,8 @@ const PrivateRoute: FC<PrivateRoutesProps> = ({ roles }) => {
   const user = useSelector((state: RootState) => state.auth.user);
 
   if (!user) {
-    return <Navigate to="/account" />;
+    // navigate to cognito logout link
+    return <Forbidden />;
   } else if (roles && !roles.includes(user.role)) {
     return <Forbidden />;
   } else {

--- a/src/components/PrivateRoutes/PrivateRoutes.tsx
+++ b/src/components/PrivateRoutes/PrivateRoutes.tsx
@@ -1,20 +1,19 @@
 import { FC } from "react";
 import { Outlet } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import Forbidden from "@/pages/ErrorPages/Forbidden";
-import { logout, type RootState } from "@/store";
+import { type RootState } from "@/store";
 
 export interface PrivateRoutesProps {
   roles?: string[];
 }
 
 const PrivateRoute: FC<PrivateRoutesProps> = ({ roles }) => {
-  const dispatch = useDispatch();
   const { user } = useSelector((state: RootState) => state.auth);
 
   if (!user) {
-    dispatch(logout());
+    return <Forbidden />;
   } else if (roles && !roles.includes(user.role)) {
     return <Forbidden />;
   } else {

--- a/src/components/PrivateRoutes/PrivateRoutes.tsx
+++ b/src/components/PrivateRoutes/PrivateRoutes.tsx
@@ -1,19 +1,22 @@
 import { FC } from "react";
 import { Outlet } from "react-router-dom";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import Forbidden from "@/pages/ErrorPages/Forbidden";
-import type { RootState } from "@/store";
+import { logout, type RootState } from "@/store";
 
 export interface PrivateRoutesProps {
   roles?: string[];
 }
 
 const PrivateRoute: FC<PrivateRoutesProps> = ({ roles }) => {
-  const user = useSelector((state: RootState) => state.auth.user);
+  const dispatch = useDispatch();
+  const { logoutUri, user } = useSelector((state: RootState) => state.auth);
 
   if (!user) {
-    // navigate to cognito logout link
+    if (logoutUri) {
+      dispatch(logout());
+    }
     return <Forbidden />;
   } else if (roles && !roles.includes(user.role)) {
     return <Forbidden />;

--- a/src/pages/Account/Login/login.tsx
+++ b/src/pages/Account/Login/login.tsx
@@ -4,8 +4,8 @@ import { Form } from "react-bootstrap";
 import { useDispatch } from "react-redux";
 
 import "./Login.scss";
-import { login } from "@/store";
 
+// Future: Remove if we want to just use Cognito login page
 const Login: FC = () => {
   const dispatch = useDispatch();
   const [email, setEmail] = useState<string>("");
@@ -22,7 +22,7 @@ const Login: FC = () => {
   const handleLogin = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
-      dispatch(login({ email, password }));
+      // dispatch(login({ email, password }));
     },
     [dispatch, email, password]
   );

--- a/src/pages/ErrorPages/ErrorPages.scss
+++ b/src/pages/ErrorPages/ErrorPages.scss
@@ -1,6 +1,7 @@
 .error-page {
   align-items: center;
   display: flex;
+  flex-direction: column;
   height: 100%;
   justify-content: center;
 }

--- a/src/pages/ErrorPages/Forbidden.tsx
+++ b/src/pages/ErrorPages/Forbidden.tsx
@@ -5,7 +5,8 @@ import "./ErrorPages.scss";
 const Forbidden: React.FC = () => {
   return (
     <div className="error-page">
-      <h1>403: Forbidden</h1>;
+      <h1>Uh-oh! We hit a snag...</h1>
+      <p>You do not have permission to access this resource.</p>
     </div>
   );
 };

--- a/src/pages/ErrorPages/NotFound.tsx
+++ b/src/pages/ErrorPages/NotFound.tsx
@@ -5,7 +5,8 @@ import "./ErrorPages.scss";
 const NotFound: React.FC = () => {
   return (
     <div className="error-page">
-      <h1>404: Page Not Found</h1>;
+      <h1>Uh-oh! We hit a snag...</h1>
+      <p>The attempted resource could not be found.</p>
     </div>
   );
 };

--- a/src/providers/GlobalProvider.tsx
+++ b/src/providers/GlobalProvider.tsx
@@ -5,28 +5,20 @@ import {
   useContext,
   useEffect,
 } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import { ModalProvider } from "./ModalProvider/ModalProvider";
-import { initialize, logout, type RootState } from "@/store";
+import { initialize } from "@/store";
 
 export const GlobalContext = createContext<undefined>(undefined);
 
 export const GlobalProvider: FC<PropsWithChildren> = ({ children }) => {
   const dispatch = useDispatch();
-  const { isInitialized, user } = useSelector((state: RootState) => state.auth);
 
   // Initialize auth state on app load
   useEffect(() => {
     dispatch(initialize());
   }, [dispatch]);
-
-  // If user is not set during auth initialization, log out
-  useEffect(() => {
-    if (isInitialized && !user) {
-      dispatch(logout());
-    }
-  }, [dispatch, isInitialized, user]);
 
   return (
     <GlobalContext.Provider value={undefined}>

--- a/src/providers/GlobalProvider.tsx
+++ b/src/providers/GlobalProvider.tsx
@@ -1,10 +1,33 @@
-import { FC, PropsWithChildren, createContext, useContext } from "react";
+import {
+  FC,
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+} from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 import { ModalProvider } from "./ModalProvider/ModalProvider";
+import { RootState, loadUser, logout } from "@/store";
 
 export const GlobalContext = createContext<undefined>(undefined);
 
 export const GlobalProvider: FC<PropsWithChildren> = ({ children }) => {
+  const dispatch = useDispatch();
+  const { loadUserAttempted, user } = useSelector(
+    (state: RootState) => state.auth
+  );
+
+  useEffect(() => {
+    dispatch(loadUser());
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (loadUserAttempted && !user) {
+      dispatch(logout());
+    }
+  }, [dispatch, loadUserAttempted, user]);
+
   return (
     <GlobalContext.Provider value={undefined}>
       <ModalProvider>{children}</ModalProvider>

--- a/src/providers/GlobalProvider.tsx
+++ b/src/providers/GlobalProvider.tsx
@@ -8,25 +8,25 @@ import {
 import { useDispatch, useSelector } from "react-redux";
 
 import { ModalProvider } from "./ModalProvider/ModalProvider";
-import { RootState, loadUser, logout } from "@/store";
+import { initialize, logout, type RootState } from "@/store";
 
 export const GlobalContext = createContext<undefined>(undefined);
 
 export const GlobalProvider: FC<PropsWithChildren> = ({ children }) => {
   const dispatch = useDispatch();
-  const { loadUserAttempted, user } = useSelector(
-    (state: RootState) => state.auth
-  );
+  const { isInitialized, user } = useSelector((state: RootState) => state.auth);
 
+  // Initialize auth state on app load
   useEffect(() => {
-    dispatch(loadUser());
+    dispatch(initialize());
   }, [dispatch]);
 
+  // If user is not set during auth initialization, log out
   useEffect(() => {
-    if (loadUserAttempted && !user) {
+    if (isInitialized && !user) {
       dispatch(logout());
     }
-  }, [dispatch, loadUserAttempted, user]);
+  }, [dispatch, isInitialized, user]);
 
   return (
     <GlobalContext.Provider value={undefined}>

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -10,8 +10,8 @@ export type AuthUser = {
 };
 
 type AuthSliceState = {
-  clientId: string;
-  loadUserAttempted: boolean;
+  isInitialized: boolean;
+  logoutUri?: string;
   user?: AuthUser;
 };
 
@@ -36,13 +36,13 @@ type CognitoUserPayload = {
 const authSlice = createSlice({
   name: "auth",
   initialState: {
-    loadUserAttempted: false,
+    isInitialized: false,
   } as AuthSliceState,
   reducers: {
-    loadUser(state) {
+    initialize(state) {
       const userIdToken = Cookies.get("id_token");
-      const clientId = Cookies.get("client_id");
-      state.loadUserAttempted = true;
+      state.logoutUri = Cookies.get("logout_uri");
+      state.isInitialized = true;
 
       if (userIdToken) {
         const decodedUserId: CognitoUserPayload =
@@ -55,17 +55,14 @@ const authSlice = createSlice({
           username: decodedUserId["cognito:username"],
         };
       }
-      if (clientId) {
-        state.clientId = clientId;
-      }
     },
     logout(state) {
-      window.location.replace(
-        `https://rent-portal-login.auth.us-east-1.amazoncognito.com/logout?response_type=code&client_id=${state.clientId}&redirect_uri=https%3A%2F%2Fportal.ebthetatauhousing.org%2Fparse-auth`
-      );
+      if (state.logoutUri) {
+        window.location.replace(state.logoutUri);
+      }
     },
   },
 });
 
 export const authReducer = authSlice.reducer;
-export const { loadUser, logout } = authSlice.actions;
+export const { initialize, logout } = authSlice.actions;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -10,7 +10,6 @@ export type AuthUser = {
 };
 
 type AuthSliceState = {
-  logoutUri?: string;
   user?: AuthUser;
 };
 
@@ -34,13 +33,10 @@ type CognitoUserPayload = {
 
 const authSlice = createSlice({
   name: "auth",
-  initialState: {
-    isInitialized: false,
-  } as AuthSliceState,
+  initialState: {} as AuthSliceState,
   reducers: {
     initialize(state) {
-      const userIdToken = Cookies.get("id_token");
-      state.logoutUri = Cookies.get("logout_uri");
+      const userIdToken = Cookies.get("user_id_token");
 
       if (userIdToken) {
         const decodedUserId: CognitoUserPayload =
@@ -54,10 +50,8 @@ const authSlice = createSlice({
         };
       }
     },
-    logout(state) {
-      if (state.logoutUri) {
-        window.location.replace(state.logoutUri);
-      }
+    logout() {
+      window.location.replace("https://portal.ebthetatauhousing.org/logout");
     },
   },
 });

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -10,7 +10,6 @@ export type AuthUser = {
 };
 
 type AuthSliceState = {
-  isInitialized: boolean;
   logoutUri?: string;
   user?: AuthUser;
 };
@@ -42,7 +41,6 @@ const authSlice = createSlice({
     initialize(state) {
       const userIdToken = Cookies.get("id_token");
       state.logoutUri = Cookies.get("logout_uri");
-      state.isInitialized = true;
 
       if (userIdToken) {
         const decodedUserId: CognitoUserPayload =

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,11 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/js-cookie@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
+  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
+
 "@types/node@^20.8.6":
   version "20.11.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.16.tgz#4411f79411514eb8e2926f036c86c9f0e4ec6708"
@@ -1270,6 +1275,11 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
+js-cookie@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
+  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1294,6 +1304,11 @@ json5@^2.2.3:
     array.prototype.flat "^1.3.1"
     object.assign "^4.1.4"
     object.values "^1.1.6"
+
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
- Change routing behavior to not route to Account page for now, as we are handling login/logout with AWS URI's
- Add in auth slice initialization action for retrieving user `id_token` and `logout_uri` cookies and setting auth state
- Add in auth slice logout action for redirecting the user to the `logout_uri` address
- Call 'Initialize' Auth Slice Action in global context on app load
- Call 'Logout' Auth Slice Function in PrivateRoutes component when user is not defined, or if the Sign Out button is clicked